### PR TITLE
Babel: Use cjs plugin only

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "tap": "^8.0.0"
   },
   "dependencies": {
-    "babel-preset-es2015": "^6.18.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
     "babelify": "^7.3.0",
     "bluebird": "^3.4.6",
     "browserify": "^13.1.1",

--- a/splittable.js
+++ b/splittable.js
@@ -148,7 +148,7 @@ exports.getGraph = function(entryModules) {
 
   // Use browserify with babel to learn about deps.
   var b = browserify(entryModules, {debug: true, deps: true})
-      .transform(babel, {presets: ["es2015"]});
+      .transform(babel, {plugins: ["transform-es2015-modules-commonjs"]});
   // This gets us the actual deps.
   b.pipeline.get('deps').push(through.obj(function(row, enc, next) {
     var id = relativePath(process.cwd(), row.id);


### PR DESCRIPTION
If this only deals with modules (I assume we want to be cjs instead of the others http://babeljs.io/docs/plugins/#modules)

Ref https://twitter.com/cramforce/status/799097621021241345