### PR TITLE
Unify file paths for Windows

### DIFF
--- a/splittable.js
+++ b/splittable.js
@@ -163,11 +163,11 @@ exports.getGraph = function(entryModules) {
       .transform(babel, {plugins: [require.resolve("babel-plugin-transform-es2015-modules-commonjs")]});
   // This gets us the actual deps.
   b.pipeline.get('deps').push(through.obj(function(row, enc, next) {
-    var id = maybeAddDotJs(relativePath(process.cwd(), row.id));
+    var id = unifyPath(maybeAddDotJs(relativePath(process.cwd(), row.id)));
     topo.addNode(id, id);
     var deps = edges[id] = Object.keys(row.deps).map(function(dep) {
       var depId = row.deps[dep];
-      var relPathtoDep = relativePath(process.cwd(), row.deps[dep]);
+      var relPathtoDep = unifyPath(relativePath(process.cwd(), row.deps[dep]));
 
       // Non relative module path. Try to find module root.
       if (!/^\./.test(dep)) {
@@ -273,6 +273,10 @@ function bundleTrailModule(name) {
       'require("' + name + '")\n';
   fs.writeFileSync(tmp.name, js, 'utf8');
   return relativePath(process.cwd(), tmp.name);
+}
+
+function unifyPath(id) {
+  return id.split(path.sep).join('/');
 }
 
 var systemImport =

--- a/test/test-generated-code.js
+++ b/test/test-generated-code.js
@@ -140,6 +140,6 @@ t.test('generated code JS API', function(t) {
 t.test('generated code command line', function(t) {
   fs.emptyDirSync('test-out/');
   child.execSync(
-      './bin.js ./sample/lib/a ./sample/lib/b --write-to=test-out/');
+      'node ./bin.js ./sample/lib/a ./sample/lib/b --write-to=test-out/');
   return testGeneratedCode(t);
 });


### PR DESCRIPTION
On windows, file paths will return with a backslash instead of a slash as described in the [documentation](https://nodejs.org/api/path.html#path_path_win32):
> Note: On Windows, both the forward slash (/) and backward slash (\) characters are accepted as path delimiters; however, only the backward slash (\) will be used in return values.

Due to this splittable is not able to proper match paths and the script will fail to resolve all dependencies as intended.

Unifying the paths before applying to the `graph` will fix this issue.

I also included a compatibility fix in the tests to ensure that all tests pass on Windows 10 (PowerShell; NodeJS v6.9.1) and the Ubuntu subsystem for windows (bash; NodeJS v6.9.1).

Ubuntu subsystem was working proper before, in PowerShell all tests failed.