### PR TITLE
Add basic support for blacklisting modules via the browser key in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splittable",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Module bundler with support for code splitting, ES6 & CommonJS modules.",
   "main": "index.js",
   "scripts": {
@@ -21,6 +21,7 @@
   "author": "cramforce",
   "license": "Apache-2.0",
   "devDependencies": {
+    "bel": "^4.5.1",
     "d3-array": "^1.0.1",
     "d3-shape": "^1.0.3",
     "fs-extra": "^1.0.0",

--- a/test/module-regression/bel.js
+++ b/test/module-regression/bel.js
@@ -1,0 +1,1 @@
+require('bel')

--- a/test/test-generated-code.js
+++ b/test/test-generated-code.js
@@ -15,7 +15,7 @@
  */
 
 var Promise = require('bluebird');
-var fs = require('fs-extra')
+var fs = require('fs-extra');
 var t = require('tap');
 var splittable = require('../index');
 var child = require('child_process');

--- a/test/test-module-regression.js
+++ b/test/test-module-regression.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 Malte Ubl.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var t = require('tap');
+var fs = require('fs-extra');
+var splittable = require('../index');
+
+t.test('module regression: bel', function(t) {
+  fs.emptyDirSync('test-out/');
+  return splittable({
+    modules: ['./test/module-regression/bel.js'],
+    writeTo: 'test-out/',
+  });
+});

--- a/test/test-splittable.js
+++ b/test/test-splittable.js
@@ -77,6 +77,7 @@ t.test('module order with 2 modules', function(t) {
       "--module", "sample-lib-b:2:_base",
       "--module_wrapper", "sample-lib-b:" + splittable.bundleWrapper,
       "--js_module_root", "./splittable-build/transformed/",
+      "--js_module_root", "./splittable-build/browser/",
       "--js_module_root", "./",
     ]);
   });
@@ -131,6 +132,7 @@ t.test('accepts different module input syntax', function(t) {
       "--module", "sample-lib-b:4",
       "--module_wrapper", "sample-lib-b:" + splittable.defaultWrapper,
       "--js_module_root", "./splittable-build/transformed/",
+      "--js_module_root", "./splittable-build/browser/",
       "--js_module_root", "./"
     ]);
   });
@@ -170,6 +172,7 @@ t.test('packages', function(t) {
       "--module_wrapper", "sample-lib-other-module-root:" +
           splittable.defaultWrapper,
       "--js_module_root", "./splittable-build/transformed/",
+      "--js_module_root", "./splittable-build/browser/",
       "--js_module_root", "./",
     ]);
   });
@@ -243,6 +246,7 @@ t.test('getFlags', function(t) {
       // For transformed files, we want to point source maps to the originals
       // because the maps actually refer to those.
       "--source_map_location_mapping","splittable-build/transformed/|/",
+      "--source_map_location_mapping","splittable-build/browser/|/",
       "--source_map_location_mapping", "|/",
       "--js", "base.js",
       "--js", "sample/lib/d.js",
@@ -251,6 +255,7 @@ t.test('getFlags', function(t) {
       "--module", "sample-lib-b:4",
       "--module_wrapper", "sample-lib-b:" + splittable.defaultWrapper,
       "--js_module_root", "./splittable-build/transformed/",
+      "--js_module_root", "./splittable-build/browser/",
       "--js_module_root", "./",
     ]);
   });

--- a/third_party/closure-compiler/REAME.splittable
+++ b/third_party/closure-compiler/REAME.splittable
@@ -6,6 +6,11 @@ Reasons to use custom release:
 - Turned off property renaming in ADVANCED mode. Otherwise React plugins break.
 - Need c4a104075d40dd2191b45de33d00b79edd45b97e
 - Applied small patch to fix https://github.com/google/closure-compiler/issues/2170
+- Fixed NPE in CommonJS rewrite path.
+
+## Work remote
+
+https://github.com/google/closure-compiler/pull/2190/files
 
 ```
 diff --git a/src/com/google/javascript/jscomp/deps/ModuleLoader.java b/src/com/google/javascript/jscomp/deps/ModuleLoader.java


### PR DESCRIPTION
- Only supports form `"module-name": true`.
- No support for module replacement yet.
- No support for relative modules yet.

Tests missing, but added compilation test for `bel` module that uses the pattern.

On top of the more high level problem, fixed a null pointer exception in handling of `module.exports` in closure compiler. See https://github.com/google/closure-compiler/pull/2190/files

Makes #38 succeed, yaihh :)