### PR TITLE
allow splittable user to use additional plugins in the deps finding pipeline

### DIFF
--- a/babel-plugins/add-module-export/src/index.js
+++ b/babel-plugins/add-module-export/src/index.js
@@ -1,0 +1,23 @@
+"use strict";
+
+module.exports = function({ types: t }) {
+  return {
+    visitor: {
+      Program(path, state) {
+        const id = path.scope.generateUidIdentifier('uid')
+        const constNumDecl = t.variableDeclaration('const', [
+          t.variableDeclarator(
+            t.identifier(id.name),
+            t.numericLiteral(42)
+          )
+        ]);
+        const exported = t.identifier(id.name);
+        const local = exported;
+        path.pushContainer('body', [
+          t.exportNamedDeclaration(constNumDecl, [
+            t.exportSpecifier(local, exported)])
+        ])
+      }
+    }
+  };
+};

--- a/splittable.js
+++ b/splittable.js
@@ -238,9 +238,10 @@ exports.getGraph = function(entryModules, config) {
   // directly and which we don't want to apply during deps finding.
   transform(babel, {
     babelrc: false,
-    plugins: [
+    plugins: Array.isArray(config.babel.plugins) ? config.babel.plugins.concat([
       require.resolve("babel-plugin-transform-es2015-modules-commonjs"),
-    ]
+    ]) : [require.resolve("babel-plugin-transform-es2015-modules-commonjs"),
+]
   });
 
   b.on('package', function(pkg) {

--- a/splittable.js
+++ b/splittable.js
@@ -228,9 +228,11 @@ exports.getGraph = function(entryModules, config) {
   // We register 2 separate transforms. The initial stage are
   // transforms that closure compiler does not support.
   .transform(babel, {
+    global: true,
     babelrc: !!config.babel.babelrc,
     plugins: config.babel.plugins || [
       require.resolve("babel-plugin-transform-react-jsx"),
+      require.resolve("./babel-plugins/add-module-export/src"),
     ],
     presets: config.babel.presets,
   }).

--- a/splittable.js
+++ b/splittable.js
@@ -238,10 +238,10 @@ exports.getGraph = function(entryModules, config) {
   // directly and which we don't want to apply during deps finding.
   transform(babel, {
     babelrc: false,
-    plugins: Array.isArray(config.babel.plugins) ? config.babel.plugins.concat([
+    plugins: [
       require.resolve("babel-plugin-transform-es2015-modules-commonjs"),
-    ]) : [require.resolve("babel-plugin-transform-es2015-modules-commonjs"),
-]
+      'transform-remove-strict-mode',
+    ]
   });
 
   b.on('package', function(pkg) {


### PR DESCRIPTION
this is needed as there are some constructs that the jison library
generates that blows up with "use strict" directive. I need to be able
to pass "transform-remove-strict-mode" plugin